### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/api-content.yaml
+++ b/.github/workflows/api-content.yaml
@@ -64,7 +64,7 @@ jobs:
       run: |
         wa=$(az webapp list -g $rg --query "[?tags.env=='${{ steps.define-env.outputs.targetEnv }}'].name" -o tsv)
         echo "Found Web App:  $wa"
-        echo "::set-output name=webAppName::$wa"
+        echo "webAppName=$wa" >> $GITHUB_OUTPUT
     # Deploy Web App, see https://learn.microsoft.com/en-us/azure/app-service/deploy-zip?tabs=cli#deploy-a-zip-package
     - name: Deploy
       run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


