### PR TITLE
Fixing issue where entity names that are integers are not escaped.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Idea/JeBrains Rider workspace files
+.idea/

--- a/code/DeltaKustoLib/CommandModel/EntityName.cs
+++ b/code/DeltaKustoLib/CommandModel/EntityName.cs
@@ -28,6 +28,13 @@ namespace DeltaKustoLib.CommandModel
             {
                 NeedEscape = true;
             }
+
+            // If the entity name is an integer, it needs to be escaped
+            if (int.TryParse(name, out _))
+            {
+                NeedEscape = true;
+            }
+            
             //  Scan the name for unsupported characters / special characters
             foreach (var c in name)
             {

--- a/code/DeltaKustoUnitTest/CommandParsing/AlterColumnTest.cs
+++ b/code/DeltaKustoUnitTest/CommandParsing/AlterColumnTest.cs
@@ -34,5 +34,19 @@ namespace DeltaKustoUnitTest.CommandParsing
             Assert.Equal(new EntityName("c "), alterColumnTypeCommand.ColumnName);
             Assert.Equal("string", alterColumnTypeCommand.Type);
         }
+        
+        [Fact]
+        public void AlterColumnIntegerNames()
+        {
+            var command = ParseOneCommand(".alter column t_able.['1'] type=string");
+
+            Assert.IsType<AlterColumnTypeCommand>(command);
+
+            var alterColumnTypeCommand = (AlterColumnTypeCommand)command;
+
+            Assert.Equal(new EntityName("t_able"), alterColumnTypeCommand.TableName);
+            Assert.Equal(new EntityName("1"), alterColumnTypeCommand.ColumnName);
+            Assert.Equal("string", alterColumnTypeCommand.Type);
+        }
     }
 }

--- a/code/DeltaKustoUnitTest/CommandParsing/CreateFunctionTest.cs
+++ b/code/DeltaKustoUnitTest/CommandParsing/CreateFunctionTest.cs
@@ -215,6 +215,27 @@ with (
             Assert.Equal("int", createFunctionCommand.Parameters.First().PrimitiveType);
             Assert.Equal(body, createFunctionCommand.Body);
         }
+        
+        [Fact]
+        public void ParameterWithIntegerName()
+        {
+            var name = "myfct";
+            var body = "print state, qty, tolerance";
+            var paramName = "1";
+            var command = ParseOneCommand(
+                ".create-or-alter function "
+                + $"{name} (['{paramName}']:string) {{ {body} }}");
+
+            Assert.IsType<CreateFunctionCommand>(command);
+
+            var createFunctionCommand = (CreateFunctionCommand)command;
+
+            Assert.Equal(name, createFunctionCommand.FunctionName.Name);
+            Assert.Single(createFunctionCommand.Parameters);
+            Assert.Equal(paramName, createFunctionCommand.Parameters.First().ParameterName.Name);
+            Assert.Equal("string", createFunctionCommand.Parameters.First().PrimitiveType);
+            Assert.Equal(body, createFunctionCommand.Body);
+        }
 
         [Fact]
         public void DefaultValueParameter()

--- a/code/DeltaKustoUnitTest/Delta/DeltaTableTest.cs
+++ b/code/DeltaKustoUnitTest/Delta/DeltaTableTest.cs
@@ -17,7 +17,7 @@ namespace DeltaKustoUnitTest.Delta
         {
             var currentCommands = new CommandBase[0];
             var currentDatabase = DatabaseModel.FromCommands(currentCommands);
-            var targetCommands = Parse(".create table t1(a: string, b: int)");
+            var targetCommands = Parse(".create table t1(a: string, b: int, ['1']: string)");
             var targetDatabase = DatabaseModel.FromCommands(targetCommands);
             var delta = currentDatabase.ComputeDelta(targetDatabase);
 
@@ -28,7 +28,7 @@ namespace DeltaKustoUnitTest.Delta
         [Fact]
         public void FromSomethingToEmpty()
         {
-            var currentCommands = Parse(".create table t1(a: string, b: int)");
+            var currentCommands = Parse(".create table t1(a: string, b: int, ['1']: string)");
             var currentDatabase = DatabaseModel.FromCommands(currentCommands);
             var targetCommands = new CommandBase[0];
             var targetDatabase = DatabaseModel.FromCommands(targetCommands);


### PR DESCRIPTION
Fixes issue #177 
If an entity name is an integer, we set the `NeedEscape` flag
Added minimal set of UTs to get some coverage.