### PR TITLE
Update Microsoft.Azure.Kusto.Language

### DIFF
--- a/code/DeltaKustoLib/DeltaKustoLib.csproj
+++ b/code/DeltaKustoLib/DeltaKustoLib.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Kusto.Language" Version="11.3.24011" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Language" Version="11.7.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Update dependency Microsoft.Azure.Kusto.Language from 11.3.24011 to 11.7.3
* Add unit tests for:
  * Function having multiline body - succeeds in 11.3.24011 (succeeds in 11.3.24011 and 11.7.3)
  * Function having multiline body containing sub query in separate parameter (succeeds in 11.3.24011 and 11.7.3)
  * Function having multiline body containing inline expression / query (fails in 11.3.24011, succeeds in 11.7.3)

Fixes: #183 
